### PR TITLE
Fix Gulp Nodemon

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -91,12 +91,18 @@ gulp.task("nodemon", done => {
   let started = false;
 
   return plugins.nodemon({
-    script: "app.js"
+    script: "app.js",
+    ignore: [
+      "node_modules/",
+      "assets/",
+      "public/"
+    ]
   }).on("start", () => {
     // Avoid nodemon being started multiple times
     if (!started) {
-      done();
       started = true;
+      // 1s should enough time for Express to be gucci
+      setTimeout(done, 1000);
     }
   });
 });


### PR DESCRIPTION
- Give Nodemon 1s buffer before starting Browser Sync
- Make Nodemon only watch server JS, not client