### PR TITLE
Fixed No Event Title Post

### DIFF
--- a/assets/js/create.js
+++ b/assets/js/create.js
@@ -83,8 +83,12 @@ $(document ).ready(function() { // document ready
     }
 
     $('#create-send-button').click( function func(){
-      events = $('#calendar').fullCalendar('clientEvents');
       title = $('#event-title').val();
+      if(!title.trim()){
+        $('#no-title-modal').addClass('is-active');;
+        return -1;
+      }
+      events = $('#calendar').fullCalendar('clientEvents');
       var calendarView = $('#calendar').fullCalendar('getView');
       var startView = calendarView.start;
       var endView = calendarView.end;
@@ -122,6 +126,10 @@ $(document ).ready(function() { // document ready
 
 
       $('#create-send-modal').addClass('is-active');
+    });
+
+    $('#close-modal-no-title').click(function func(){
+      $('#no-title-modal').removeClass('is-active');
     });
 
     $('#close-modal').click(function func(){

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -55,7 +55,7 @@ function checkURL(){
     $('#invalid-msg').html("please check to make sure you have the correct event code")
     $('#invalid-id-modal').addClass('is-active');
   }else if(window.location.href.indexOf("invalid-code=2") > -1){
-    // code couln't be decoded
+    // code couldn't be decoded
     $('#id-header').html("Invalid Event Code");
     $('#invalid-title').html("Your Event Code Is Not Valid!");
     $('#invalid-msg').html("please check to make sure you have the correct event code")

--- a/views/create.njk
+++ b/views/create.njk
@@ -73,6 +73,17 @@
           </div>
         </div>
       </nav>
+      <div class="modal" id="no-title-modal">
+        <form id="modal-form">
+        <div class="modal-background"></div>
+        <div class="modal-card">
+          <header class="modal-card-head">
+            <p class="modal-card-title">Please Enter an Event Title!</p>
+            <button type="button" class="delete" id="close-modal-no-title" aria-label="close"></button>
+          </header>
+        </div>
+        </form>
+      </div>
       <div class="modal" id="create-send-modal">
         <form id="modal-form">
         <div class="modal-background"></div>


### PR DESCRIPTION
Fixed no Event Title so that a user cannot even open the create-send modal without an event title. If there is no event title modal pops up saying "Please Enter an Event Title".